### PR TITLE
Add gulp-bundlerify and refactor the gulpfile

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,52 @@
+{
+  'parser': 'babel-eslint',
+  'env': {
+    'es6': true
+  },
+  'ecmaFeatures': {
+    'arrowFunctions': true,
+    'blockBindings': true,
+    'classes': true,
+    'defaultParams': true,
+    'destructuring': true,
+    'forOf': true,
+    'generators': false,
+    'modules': true,
+    'objectLiteralComputedProperties': true,
+    'objectLiteralDuplicateProperties': false,
+    'objectLiteralShorthandMethods': true,
+    'objectLiteralShorthandProperties': true,
+    'spread': true,
+    'superInFunctions': true,
+    'templateStrings': true,
+    'jsx': true
+  },
+  'rules': {
+    // require parens in arrow function arguments
+    'arrow-parens': 0,
+    // require space before/after arrow function's arrow
+    'arrow-spacing': 0,
+    // verify super() callings in constructors
+    'constructor-super': 0,
+    // enforce the spacing around the * in generator functions
+    'generator-star-spacing': 0,
+    // disallow modifying variables of class declarations
+    'no-class-assign': 0,
+    // disallow modifying variables that are declared using const
+    'no-const-assign': 0,
+    // disallow to use this/super before super() calling in constructors.
+    'no-this-before-super': 0,
+    // require let or const instead of var
+    'no-var': 2,
+    // require method and property shorthand syntax for object literals
+    'object-shorthand': 0,
+    // suggest using of const declaration for variables that are never modified after declared
+    'prefer-const': 2,
+    // suggest using the spread operator instead of .apply()
+    'prefer-spread': 0,
+    // suggest using Reflect methods where applicable
+    'prefer-reflect': 0,
+    // disallow generator functions that do not have yield
+    'require-yield': 0
+  }
+}

--- a/app/js/components/Playlist.js
+++ b/app/js/components/Playlist.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import React, {Component} from 'react';
-import Track from './track';
+import Track from './Track';
 import {open} from '../actions/ModalActions';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,63 +1,45 @@
 var gulp = require('gulp');
-var fs = require('fs');
-var browserify = require('browserify');
-var watchify = require('watchify');
-var babelify = require('babelify');
-var rimraf = require('rimraf');
-var source = require('vinyl-source-stream');
-var _ = require('lodash');
-var browserSync = require('browser-sync');
-var reload = browserSync.reload;
-var streamify = require('gulp-streamify');
-var uglify = require('gulp-uglify');
 var args   = require('yargs').argv;
-var gulpif = require('gulp-if');
-var jshint = require('gulp-jshint');
-var stylish = require('jshint-stylish');
 var minifyCss = require('gulp-minify-css');
+var Bundlerify = require('gulp-bundlerify').default;
+var oldBabelify = require('babelify');
 
 var isProduction = args.production === true;
 
-var config = {
-  entryFile: './app/js/app.js',
-  outputDir: './dist/js',
-  outputFile: 'build.js'
-};
+var bundler = new Bundlerify(gulp, {
+  mainFile: './app/js/app.js',
+  dist: {
+    dir: './dist/js/',
+  },
+  watchifyOptions: {
+    fullPaths: false,
+    debug: !isProduction,
+  },
+  browserSyncOptions: {
+    server: {
+      baseDir: './app/',
+      directory: false,
+    },
+  },
+  babelifyOptions: {
+    presets: ['react'],
+  },
+  polyfillsEnabled: isProduction,
+  uglify: isProduction,
+  lint: {
+    target: ['./app/js/**/*.js'],
+  },
+  tasks: {
+    build: {
+      deps: isProduction ? ['css', 'img', 'html'] : [],
+    },
+    docs: false,
+  },
+}).tasks();
 
-// clean the output directory
-gulp.task('clean', function(cb) {
-  rimraf(config.outputDir, cb);
-});
-
-var bundler;
-function getBundler() {
-  if (!bundler) {
-    if (isProduction) {
-      bundler = watchify(
-        browserify([
-          require.resolve('whatwg-fetch/fetch'),
-          require.resolve('core-js/fn/symbol'),
-          require.resolve('core-js/fn/promise'),
-          config.entryFile], _.extend({ debug: true }, watchify.args)));
-    } else {
-      bundler = watchify(
-        browserify(config.entryFile, _.extend({ debug: !isProduction }, watchify.args))
-        );
-    }
-  }
-  return bundler;
-};
-
-function bundle() {
-  return getBundler()
-    .transform(babelify)
-    .bundle()
-    .on('error', function(err) { console.log('Error: ' + err.message); })
-    .pipe(source(config.outputFile))
-    .pipe(gulpif(isProduction, streamify(uglify())))
-    .pipe(gulp.dest(config.outputDir))
-    .pipe(reload({ stream: true }));
-}
+// Remove these two lines to upgrade to Babel 6
+bundler.babelify = oldBabelify;
+delete bundler.config.babelifyOptions.presets;
 
 gulp.task('css', function() {
   gulp.src('./app/styles/style.css')
@@ -75,42 +57,4 @@ gulp.task('html', function() {
     .pipe(gulp.dest('./dist/'));
   gulp.src('./app/login/index.html')
     .pipe(gulp.dest('./dist/login'));
-});
-
-gulp.task('build-persistent-deploy', ['clean', 'css', 'img', 'html'], function() {
-  return bundle();
-});
-
-gulp.task('build-persistent', ['clean'], function() {
-  return bundle();
-});
-
-gulp.task('deploy', ['build-persistent-deploy'], function() {
-  process.exit(0);
-});
-
-gulp.task('build', ['build-persistent'], function() {
-  process.exit(0);
-});
-
-gulp.task('watch', ['build-persistent'], function() {
-
-  browserSync({
-    server: {
-      baseDir: './'
-    }
-  });
-
-  getBundler().on('update', function() {
-    gulp.start('build-persistent');
-  });
-});
-
-// WEB SERVER
-gulp.task('serve', function() {
-  browserSync({
-    server: {
-      baseDir: './'
-    }
-  });
 });

--- a/package.json
+++ b/package.json
@@ -5,24 +5,11 @@
   "devDependencies": {
     "babel-jest": "5.3.0",
     "babelify": "6.4.0",
-    "browser-sync": "2.9.11",
-    "browserify": "11.2.0",
     "gulp": "3.9.0",
-    "gulp-if": "2.0.0",
-    "gulp-jshint": "1.11.2",
     "gulp-minify-css": "^1.2.1",
-    "gulp-rename": "1.2.2",
-    "gulp-streamify": "1.0.2",
-    "gulp-uglify": "1.4.2",
     "jest-cli": "0.6.1",
-    "jshint-stylish": "2.0.1",
-    "lodash": "3.10.1",
-    "rimraf": "latest",
-    "vinyl-source-stream": "1.1.0",
-    "watchify": "3.5.0",
     "yargs": "3.29.0",
-    "core-js": "^1.2.0",
-    "whatwg-fetch": "^0.9.0"
+    "gulp-bundlerify": "1.0.2"
   },
   "dependencies": {
     "flux": "2.1.1",
@@ -33,9 +20,11 @@
     "spotify-sdk": "0.0.28"
   },
   "scripts": {
-    "dev": "gulp watch",
+    "start": "npm run dev",
+    "dev": "gulp serve",
     "build": "gulp build",
-    "deploy": "NODE_ENV=production gulp deploy --production",
+    "deploy": "NODE_ENV=production gulp build --production",
+    "lint": "gulp lint",
     "test": "jest"
   },
   "author": "loverajoel",


### PR DESCRIPTION
#### What does this PR do?
- Adds [gulp-bundlerify](https://github.com/homer0/gulp-bundlerify) to manage the basic tasks.
- Refactors the `gulpfile.js` using [gulp-bundlerify](https://github.com/homer0/gulp-bundlerify).
- Adds  the `.eslintrc` file for [ESLint](http://eslint.org/) so it can work with the new `lint` task.
- Removes `jshint` in favor of [ESLint](http://eslint.org/).
- Changes the `npm` tasks a little bit to use with the new tasks.
#### How should this be manually tested?
1. Run `npm start` or `npm run dev` to start the test server. Make sure everything works as it should.
2. Run `npm run build` and make sure the build it's generated.
3. Run `npm run deploy` and make sure the build the assets are generated.
4. Run `npm run lint`, it should lint the app code.
#### Any background context you want to provide?

This still uses [Babelify](https://github.com/babel/babelify) `6.4.0` because the code it's not yet compatible with [Babel](https://babeljs.io) `6.0`. Whenever you are ready to migrate, just more lines `41` and `42` from the `gulpfile.js`.

Enjoy :skull: 
