### PR TITLE
add tag preload=none in order to prevent load the preview songs

### DIFF
--- a/app/js/components/Player.js
+++ b/app/js/components/Player.js
@@ -81,7 +81,7 @@ class Track extends Component {
               { this.state.isLoading ?
                 <img src='img/tail-spin.svg' className='player-loading'/> : null
               }
-              <audio ref='audio' src={this.props.source}/>
+              <audio ref='audio' src={this.props.source} preload='none'/>
             </div>;
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Add a property `preload='none'` to audio tag, in order to prevent load the audio file
#### What are the relevant tickets? 
https://github.com/loverajoel/magicplaylist/issues/7