### PR TITLE
[FEATURE] Add more songs to playlist

### DIFF
--- a/app/js/actions/PlaylistActions.js
+++ b/app/js/actions/PlaylistActions.js
@@ -29,7 +29,8 @@ let PlaylistActions = {
         Dispatcher.dispatch({
           type: PLAYLIST_ADD_TRACKS,
           tracks: tracks,
-          mainTrack: mainTrack
+          mainTrack: mainTrack,
+          playlistLength: playlistLength
         });
         ga('send', 'event', 'event', 'new-playlist', 'new');
       } else {

--- a/app/js/actions/PlaylistActions.js
+++ b/app/js/actions/PlaylistActions.js
@@ -20,11 +20,11 @@ import {login} from './UserActions';
 
 let PlaylistActions = {
 
-  search: (text, country) => {
+  search: (text, country, playlistLength) => {
     Dispatcher.dispatch({
       type: PLAYLIST_LOADING
     });
-    Spotify.search(text, country, (tracks, mainTrack) => {
+    Spotify.search(text, country, playlistLength, (tracks, mainTrack) => {
       if (tracks.length) {
         Dispatcher.dispatch({
           type: PLAYLIST_ADD_TRACKS,

--- a/app/js/components/Modal.js
+++ b/app/js/components/Modal.js
@@ -32,11 +32,13 @@ class Modal extends Component {
 
   _savePlaylist() {
     const playlistName = ReactDOM.findDOMNode(this.refs.playlistName).value;
+    const playlistTracks = PlaylistStore.getTracks().slice(0, PlaylistStore.getPlaylistLength());
     close();
     save(
       UserStore.getUser()._id,
       playlistName,
-      this.state.playlistPublic, PlaylistStore.getTracks()
+      this.state.playlistPublic,
+      playlistTracks
     );
   }
 

--- a/app/js/components/Playlist.js
+++ b/app/js/components/Playlist.js
@@ -6,13 +6,15 @@ import {open} from '../actions/ModalActions';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import PlaylistStore from '../stores/PlaylistStore';
 import PlaylistActions from '../actions/PlaylistActions';
+import { PLAYLIST_DEFAULT_SIZE } from '../constants/constants';
 
 class Playlist extends Component {
 
   constructor(props) {
     super(props);
     this.state = {
-      audios: []
+      audios: [],
+      trackCount: PlaylistStore.getPlaylistLength()
     };
   }
 
@@ -24,9 +26,15 @@ class Playlist extends Component {
   _handle10More() {
       const trackName = this.props.mainTrack.name;
       const country = this.props.country;
-      const playlistLength = PlaylistStore.getTracks().length + 10;
+      const totalTracks = PlaylistStore.getTracks().length;
+      const newPlaylistLength = this.state.trackCount + 10;
 
-      PlaylistActions.search(trackName, country, playlistLength);
+      if (newPlaylistLength > totalTracks) {
+        PlaylistActions.search(trackName, country, newPlaylistLength);
+      } else {
+        const newTrackCount = this.state.trackCount + 10;
+        this.setState({ 'trackCount': newTrackCount });
+      }
   }
 
   _add(elem) {
@@ -40,7 +48,9 @@ class Playlist extends Component {
   }
 
   render() {
-    var tracks = this.props.tracks.map((track, i) => {
+    var trackCount = this.state.trackCount;
+    var firstTracks = this.props.tracks.slice(0, trackCount + 1);
+    var tracks = firstTracks.map((track, i) => {
       return <Track
                 track={track}
                 key={'track_' + track._id}

--- a/app/js/components/Playlist.js
+++ b/app/js/components/Playlist.js
@@ -4,6 +4,8 @@ import React, {Component} from 'react';
 import Track from './track';
 import {open} from '../actions/ModalActions';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import PlaylistStore from '../stores/PlaylistStore';
+import PlaylistActions from '../actions/PlaylistActions';
 
 class Playlist extends Component {
 
@@ -17,6 +19,14 @@ class Playlist extends Component {
   _handleSave() {
     open();
     ga('send', 'event', 'button', 'click', 'open-modal-save-playlist');
+  }
+
+  _handle10More() {
+      const trackName = this.props.mainTrack.name;
+      const country = this.props.country;
+      const playlistLength = PlaylistStore.getTracks().length + 10;
+
+      PlaylistActions.search(trackName, country, playlistLength);
   }
 
   _add(elem) {
@@ -65,8 +75,14 @@ class Playlist extends Component {
                 transitionLeaveTimeout={0}
               >
                 {tracks}
+                { this.props.tracks.length ?
+                  <li className='add-more-songs' onClick={this._handle10More.bind(this)}>
+                    <span className='add-more-songs-text'>+10 please!</span>
+                  </li> : null
+                }
               </ReactCSSTransitionGroup>
               </ul>
+
             </div>;
   }
 }

--- a/app/js/components/SearchBox.js
+++ b/app/js/components/SearchBox.js
@@ -20,7 +20,7 @@ class SearchBox extends Component {
 
   _search(text) {
     newSearch(text);
-    PlaylistActions.search(text, this.props.country);
+    PlaylistActions.search(text, this.props.country, 30);
     ga('send', 'event', 'event', 'new-search', text);
   }
 

--- a/app/js/components/SearchBox.js
+++ b/app/js/components/SearchBox.js
@@ -6,6 +6,7 @@ import Autosuggest from 'react-autosuggest';
 
 import {newSearch} from '../actions/SearchActions';
 import PlaylistActions from '../actions/PlaylistActions';
+import { PLAYLIST_DEFAULT_SIZE } from '../constants/constants';
 
 import Spotify from '../core/Spotify';
 
@@ -20,7 +21,7 @@ class SearchBox extends Component {
 
   _search(text) {
     newSearch(text);
-    PlaylistActions.search(text, this.props.country, 30);
+    PlaylistActions.search(text, this.props.country, PLAYLIST_DEFAULT_SIZE);
     ga('send', 'event', 'event', 'new-search', text);
   }
 

--- a/app/js/constants/constants.js
+++ b/app/js/constants/constants.js
@@ -14,6 +14,7 @@ export default {
   PLAYLIST_TRACK_NOT_FOUND: 'paylist-track-not-found',
   PLAYLIST_SAVE_FAIL: 'paylist-save-fail',
   PLAYLIST_LIMIT_429: 'playlist-limit',
+  PLAYLIST_DEFAULT_SIZE: 30,
   MODAL_OPEN: 'modal-open',
   MODAL_CLOSE: 'modal-close',
   USER_LOGED: 'user-loged',

--- a/app/js/core/Magic.js
+++ b/app/js/core/Magic.js
@@ -80,8 +80,8 @@ let orderByPopularity = (list) => {
   }).reverse();
 };
 
-let magic = (list, points) => {
-  return alternate(orderByPopularity(closest(alternate(orderByPopularity(list)), points, 30)));
+let magic = (list, points, playlistLength) => {
+  return alternate(orderByPopularity(closest(alternate(orderByPopularity(list)), points, playlistLength)));
 };
 
 export default {

--- a/app/js/core/Magic.js
+++ b/app/js/core/Magic.js
@@ -1,6 +1,8 @@
 'use strict';
 // Magic algorithm
 
+import { PLAYLIST_DEFAULT_SIZE } from '../constants/constants';
+
 let closest = function(list, x, cant) {
   let final_list = [];
   let final_cant = list.length > cant ? cant : list.length;
@@ -81,7 +83,8 @@ let orderByPopularity = (list) => {
 };
 
 let magic = (list, points, playlistLength) => {
-  return alternate(orderByPopularity(closest(alternate(orderByPopularity(list)), points, playlistLength)));
+  const trackSize = playlistLength + PLAYLIST_DEFAULT_SIZE;
+  return alternate(orderByPopularity(closest(alternate(orderByPopularity(list)), points, trackSize)));
 };
 
 export default {

--- a/app/js/core/Spotify.js
+++ b/app/js/core/Spotify.js
@@ -29,13 +29,13 @@ let Spotify = {
   autocomplete: (text, country) => {
     return track.search(text, {limit: 5, market: country});
   },
-  search: (text, country, callback, fail) => {
+  search: (text, country, playlistLength, callback, fail) => {
     if (text.id) {
-      return Spotify.getTracks(text, country, callback, fail);
+      return Spotify.getTracks(text, country, playlistLength, callback, fail);
     } else {
       track.search(text, {limit: 1, market: country}).then((trackCollection) => {
         if (trackCollection.length) {
-          Spotify.getTracks(trackCollection.first(), country, callback, fail);
+          Spotify.getTracks(trackCollection.first(), country, playlistLength, callback, fail);
         } else {
           callback([]);
         }
@@ -43,7 +43,7 @@ let Spotify = {
     }
   },
 
-  getTracks: (track, country, callback, fail) => {
+  getTracks: (track, country, playlistLength, callback, fail) => {
     Spotify.trackList = [];
     track.artists.first().relatedArtists().then((relatedArtists) => {
       relatedArtists = relatedArtists.slice(0, settings.artists - 1);
@@ -61,7 +61,8 @@ let Spotify = {
                     callback(
                       magic(
                         Spotify.trackList,
-                        track.popularity
+                        track.popularity,
+                        playlistLength
                         ), track
                       );
                   }

--- a/app/js/stores/PlaylistStore.js
+++ b/app/js/stores/PlaylistStore.js
@@ -9,6 +9,7 @@ import {
   PLAYLIST_REMOVE_TRACKS,
   PLAYLIST_CREATED,
   PLAYLIST_SAVING,
+  PLAYLIST_DEFAULT_SIZE,
   PLAYLIST_TRACK_NOT_FOUND,
   SEARCH_RESET
 } from '../constants/constants';
@@ -16,6 +17,7 @@ import {
 let CHANGE_EVENT = 'change';
 
 let _tracks = [];
+let _playlistLength = PLAYLIST_DEFAULT_SIZE;
 let _mainTrack;
 let _loading = false;
 let _lastPlaylist;
@@ -28,6 +30,10 @@ class PlaylistStore extends EventEmitter {
 
   getTracks() {
     return _tracks;
+  }
+
+  getPlaylistLength() {
+    return _playlistLength;
   }
 
   getMainTrack() {
@@ -63,6 +69,7 @@ class PlaylistStore extends EventEmitter {
         case PLAYLIST_ADD_TRACKS: {
           _tracks = tracks;
           _mainTrack = action.mainTrack;
+          _playlistLength = action.playlistLength;
           _loading = false;
           this.emitChange();
           break;

--- a/app/styles/style.css
+++ b/app/styles/style.css
@@ -295,6 +295,12 @@ a {
   padding: 13px 10px
 }
 
+.tracklist li.add-more-songs {
+  border-bottom: none;
+  text-align: center;
+  padding-top: 25px;
+}
+
 .trackList li .remove {
   width: 24px;
   height: 24px;
@@ -969,4 +975,12 @@ a {
   -o-transition-delay: 0ms;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
+}
+
+.add-more-songs-text {
+  color: gold;
+  cursor: pointer;
+  border: 1px solid gold;
+  border-radius: 50px;
+  padding: 5px 15px;
 }


### PR DESCRIPTION
The purpose of this Pull Request is to allow more tracks to be added to the playlist, as 30 may not be enough.

This was done creating a new button in the Playlist component `render()` function, and storing a slightly larger number of tracks in the state of the app (by default, 60 instead of the old 30) and, if even more tracks are requested, a new event is dispatched, following the Dispatcher pattern already found in the project. We had to modify a couple of files in order to accommodate the new feature, like storing current number of tracks, only saving current shown tracks, and other minor things like that =).

This was a work done by me (@gpiress), @luizpericolo and @matheusrma. We found the project very enjoyable and we send our best regards from Brazil =). Btw, we are looking forward for code reviews.
